### PR TITLE
Set ESLint environment to `es6`

### DIFF
--- a/vendor/package.json
+++ b/vendor/package.json
@@ -12,7 +12,8 @@
   },
   "eslintConfig": {
     "env": {
-      "node": true
+      "node": true,
+      "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {


### PR DESCRIPTION
...to prevent `no-undef`-errors on the global `Promise` object

See https://github.com/eslint/eslint/issues/9812