### PR TITLE
Refactor where starter project version is determined

### DIFF
--- a/create-project.js
+++ b/create-project.js
@@ -9,7 +9,7 @@ import tar from 'tar'
 
 const require = createRequire(import.meta.url)
 
-export async function createProject ({ dest, path, name }) {
+export async function createProject ({ dest, path, name, starterProjectVersion = 9999 }) {
     let looseName = /^[a-z][a-zA-Z0-9-_]+$/
     let appName = 'my-enhance-app'
     if (name) {
@@ -36,7 +36,7 @@ export async function createProject ({ dest, path, name }) {
 
     try {
         // Get tarball url
-        const latestUrl = await computeTarballUrl()
+        const latestUrl = await computeTarballUrl(starterProjectVersion)
 
         // Download the starter project
         await downloadStarterProject(latestUrl, starterProjectArchive)
@@ -103,12 +103,9 @@ async function downloadStarterProject(url, dest) {
     })
 }
 
-async function computeTarballUrl() {
+async function computeTarballUrl(starterProjectVersion) {
     // Get url to latest starter project
     const { body } = await tiny.get({url: 'https://registry.npmjs.org/@enhance/starter-project'})
-
-    // Need to pin major version set in package.json
-    const { starterProjectVersion } = require('./package.json')
 
     // get keys from body.version
     const latestVer = body['dist-tags'].latest

--- a/index.js
+++ b/index.js
@@ -6,8 +6,14 @@ import { resolve } from 'path'
 import { failure, success } from './console.js'
 import { createProject } from './create-project.js'
 
+import { createRequire } from 'module'
+
 const args = process.argv.slice(2, process.argv.length)
 const path = args[0]
+const require = createRequire(import.meta.url)
+
+// Need to pin major version set in package.json
+const { starterProjectVersion } = require('./package.json')
 
 if (!path) {
   throw Error('Missing path. Pass a pathname to create a new project.')
@@ -16,7 +22,7 @@ if (!path) {
 const dest = resolve(process.cwd(), path)
 
 try {
-  await createProject({ path, dest })
+  await createProject({ path, dest, starterProjectVersion })
   success({ path, dest })
 }
 catch (e) {


### PR DESCRIPTION
In order to be able to re-use this code in the Begin CLI I needed to refactor where we determine the starter project version. Taking it out of create project allows me to build a CJS version of that file that can be used in the Begin CLI.

Signed-off-by: macdonst <simon.macdonald@gmail.com>