### PR TITLE
Use copy instead of rename if temp directory is on a different device

### DIFF
--- a/create-project.js
+++ b/create-project.js
@@ -1,14 +1,11 @@
-import { randomUUID } from 'crypto';
-import { createWriteStream, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
-import fsExtra from 'fs-extra'
+import { randomUUID } from 'crypto'
+import { createWriteStream, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync, cpSync, rmSync } from 'fs'
 import { createRequire } from 'module'
 import { tmpdir } from 'os'
 import { isAbsolute, join, resolve, parse } from 'path'
 import https from 'https'
 import tiny from 'tiny-json-http'
 import tar from 'tar'
-
-const { copySync } = fsExtra;
 
 const require = createRequire(import.meta.url)
 
@@ -50,15 +47,17 @@ export async function createProject ({ dest, path, name }) {
         // Move starter project to final destination
         
         // Check if the temp and projectDir are on the same file system
-        const tempRoot = parse(temp).root;
-        const projectRoot = parse(projectDir).root;
-        const isSameFileSystemRoot = tempRoot === projectRoot;
+        const tempRoot = parse(temp).root
+        const projectRoot = parse(projectDir).root
+        const isSameFileSystemRoot = tempRoot === projectRoot
+        const packageDir = join(temp, 'package')
 
         if (!isSameFileSystemRoot) {
             // if not, we need to copy the files instead of moving them
-            copySync(join(temp, 'package'), projectDir)
+            cpSync(packageDir, projectDir, {recursive:true})
+            rmSync(packageDir, { recursive: true })
         } else {
-            renameSync(join(temp, 'package'), projectDir)
+            renameSync(packageDir, projectDir)
         }
 
         // Clean up download

--- a/create-project.js
+++ b/create-project.js
@@ -54,7 +54,7 @@ export async function createProject ({ dest, path, name }) {
 
         if (!isSameFileSystemRoot) {
             // if not, we need to copy the files instead of moving them
-            cpSync(packageDir, projectDir, {recursive:true})
+            cpSync(packageDir, projectDir, { recursive: true })
             rmSync(packageDir, { recursive: true })
         } else {
             renameSync(packageDir, projectDir)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "tape": "^5.6.3"
   },
   "dependencies": {
-    "fs-extra": "^11.1.1",
     "tar": "^6.1.14",
     "tiny-json-http": "^7.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tape": "^5.6.3"
   },
   "dependencies": {
+    "fs-extra": "^11.1.1",
     "tar": "^6.1.14",
     "tiny-json-http": "^7.5.1"
   },


### PR DESCRIPTION
Running `npx "@enhance/create@latest" ./myproject -y` on Windows when the temp directory isn't on the same disk/device as the project directory fails with `Error: EXDEV: cross-device link not permitted`.

Using copySync instead of renameSync fixes the scenario but I'm not sure if the change in this PR is a good idea or not.